### PR TITLE
Prevent uglify fail if files are not only js.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var gulp = require('gulp'),
     webpack = require('gulp-webpack'),
     gulpIf = require('gulp-if'),
     uglify = require('gulp-uglify'),
+    gulpFilter = require('gulp-filter'),
     _ = require('underscore'),
     elixir = require('laravel-elixir'),
     utilities = require('laravel-elixir/ingredients/commands/Utilities'),
@@ -9,6 +10,7 @@ var gulp = require('gulp'),
 
 elixir.extend('webpack', function (src, options) {
     var config = this;
+    var filter = gulpFilter(['*.js']);
 
     options = _.extend({
         debug:     ! config.production,
@@ -26,7 +28,9 @@ elixir.extend('webpack', function (src, options) {
 
         return gulp.src(src)
             .pipe(webpack(options)).on('error', onError)
+            .pipe(filter)
             .pipe(gulpIf(! options.debug, uglify()))
+            .pipe(filter.restore())
             .pipe(gulp.dest(options.outputDir))
             .pipe(new notification().message('Webpack Compiled!'));
     });

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "gulp-filter": "^2.0.2",
     "gulp-if": "^1.2.5",
     "gulp-notify": "^2.0.0",
     "gulp-webpack": "^1.2.0",


### PR DESCRIPTION
My webpack config

```
mix.webpack('app.js', {
  outputDir: "public/js",
  output: {
    filename: 'app.js',
  },
  module: {
    loaders: [
      {
        test: /\.jsx?$/,
        exclude: /(node_modules|bower_components)/,
        loader: 'babel'
      },
      {
        test: /\.scss$/,
        loader: 'style!css?sourceMap!ruby-sass'
      },
      {
        test: /\.css$/,
        loader: "style-loader!css-loader"
      },
      {
        test: /\.(jpe?g|png|gif|svg)$/i,
        loader: 'url?limit=10000!img?progressive=true?'
      },
      {
        test: /is_js/,
        loader: "imports?define=>undefined"
      }
    ]
  }
});
```

And I use [fancybox](https://github.com/fancyapps/fancyBox) package, the package include some images (ex:[fancybox_loading@2x.gif](https://github.com/fancyapps/fancyBox/blob/master/source/fancybox_loading%402x.gif)) and file size over 10000 bytes (I set 10000 bytes in the webpack config)
So webpack will copy images to the `public/js` directory.
If I type `gulp --production` and I got error.

```
CasperdeMacBook-Pro:accerp (develop*) $ gulp --production
[16:08:08] Using gulpfile ~/Develop/web/km/accerp/gulpfile.js
[16:08:08] Starting 'default'...
[16:08:08] Starting 'clean'...
[16:08:08] Finished 'default' after 5.96 ms
[16:08:08] Finished 'clean' after 14 ms
[16:08:08] Starting 'styles'...
[16:08:08] Merging: resources/assets/css/**/*.css
[16:08:09] Finished 'styles' after 152 ms
[16:08:09] Starting 'webpack'...

stream.js:94
      throw er; // Unhandled stream error in pipe.
            ^
Error
    at new JS_Parse_Error (/Users/casperlai/Develop/web/km/accerp/node_modules/laravel-elixir-webpack/node_modules/gulp-uglify/node_modules/uglify-js/lib/parse.js:196:18)
    at js_error (/Users/casperlai/Develop/web/km/accerp/node_modules/laravel-elixir-webpack/node_modules/gulp-uglify/node_modules/uglify-js/lib/parse.js:204:11)
    at parse_error (/Users/casperlai/Develop/web/km/accerp/node_modules/laravel-elixir-webpack/node_modules/gulp-uglify/node_modules/uglify-js/lib/parse.js:314:55)
    at Object.next_token [as input] (/Users/casperlai/Develop/web/km/accerp/node_modules/laravel-elixir-webpack/node_modules/gulp-uglify/node_modules/uglify-js/lib/parse.js:562:9)
    at peek (/Users/casperlai/Develop/web/km/accerp/node_modules/laravel-elixir-webpack/node_modules/gulp-uglify/node_modules/uglify-js/lib/parse.js:653:56)
    at /Users/casperlai/Develop/web/km/accerp/node_modules/laravel-elixir-webpack/node_modules/gulp-uglify/node_modules/uglify-js/lib/parse.js:760:29
    at /Users/casperlai/Develop/web/km/accerp/node_modules/laravel-elixir-webpack/node_modules/gulp-uglify/node_modules/uglify-js/lib/parse.js:722:24
    at /Users/casperlai/Develop/web/km/accerp/node_modules/laravel-elixir-webpack/node_modules/gulp-uglify/node_modules/uglify-js/lib/parse.js:1469:23
    at Object.parse (/Users/casperlai/Develop/web/km/accerp/node_modules/laravel-elixir-webpack/node_modules/gulp-uglify/node_modules/uglify-js/lib/parse.js:1479:7)
    at /Users/casperlai/Develop/web/km/accerp/node_modules/laravel-elixir-webpack/node_modules/gulp-uglify/node_modules/uglify-js/tools/node.js:83:33
```

Because `public/js` directory include images, uglify will be broken.

PR will filter js should be uglify.
