### PR TITLE
Replace gulp-filter

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var gulp = require('gulp'),
     webpack = require('gulp-webpack'),
     gulpIf = require('gulp-if'),
     uglify = require('gulp-uglify'),
-    gulpFilter = require('gulp-filter'),
+    gulpIgnore = require('gulp-ignore'),
     _ = require('underscore'),
     elixir = require('laravel-elixir'),
     utilities = require('laravel-elixir/ingredients/commands/Utilities'),
@@ -10,7 +10,6 @@ var gulp = require('gulp'),
 
 elixir.extend('webpack', function (src, options) {
     var config = this;
-    var filter = gulpFilter(['*.js']);
 
     options = _.extend({
         debug:     ! config.production,
@@ -28,9 +27,8 @@ elixir.extend('webpack', function (src, options) {
 
         return gulp.src(src)
             .pipe(webpack(options)).on('error', onError)
-            .pipe(filter)
+            .pipe(gulpIgnore.include('*.js'))
             .pipe(gulpIf(! options.debug, uglify()))
-            .pipe(filter.restore())
             .pipe(gulp.dest(options.outputDir))
             .pipe(new notification().message('Webpack Compiled!'));
     });

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "gulp-filter": "^2.0.2",
+    "gulp-ignore": "^1.2.1",
     "gulp-if": "^1.2.5",
     "gulp-notify": "^2.0.0",
     "gulp-webpack": "^1.2.0",


### PR DESCRIPTION
`gulp watch` will broken, when gulp run again `webpack`
I replace gulp-filter package to fix it.

```
CasperdeMacBook-Pro:accident-chart (master*) $ gulp watch
[10:53:23] Requiring external module babel/register
[10:53:26] Using gulpfile ~/Develop/web/mlshb/accident-chart/gulpfile.babel.js
[10:53:26] Starting 'watch'...
[10:53:26] Starting 'sass'...
[10:53:26] Running Sass: resources/assets/sass/app.scss
[10:53:26] Finished 'watch' after 514 ms
[10:53:26] gulp-notify: [Laravel Elixir] Sass Compiled!
[10:53:26] Finished 'sass' after 626 ms
[10:53:26] Starting 'webpack'...
[10:53:30] Version: webpack 1.10.5
             Asset     Size  Chunks             Chunk Names
     app.bundle.js   679 kB       0  [emitted]  app
excanvas.bundle.js  44.2 kB       1  [emitted]  excanvas
  system.bundle.js   452 kB       2  [emitted]  system
[10:53:30] gulp-notify: [Laravel Elixir] Webpack Compiled!
[10:53:30] Finished 'webpack' after 3.95 s
[10:53:30] Starting 'version'...
[10:53:30] Versioning: public/css/app.css, public/js/app.bundle.js, public/js/excanvas.bundle.js, public/js/system.bundle.js
[10:53:30] Finished 'version' after 84 ms
[10:53:30] Starting 'watch-assets'...
[10:53:30] Finished 'watch-assets' after 35 ms
[10:54:19] Starting 'webpack'...
stream.js:94
      throw er; // Unhandled stream error in pipe.
            ^
Error: write after end
    at writeAfterEnd (/Users/casperlai/Develop/web/mlshb/accident-chart/node_modules/laravel-elixir-webpack/node_modules/gulp-filter/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:144:12)
    at DestroyableTransform.Writable.write (/Users/casperlai/Develop/web/mlshb/accident-chart/node_modules/laravel-elixir-webpack/node_modules/gulp-filter/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:192:5)
    at Stream.ondata (stream.js:51:26)
    at Stream.emit (events.js:107:17)
    at drain (/Users/casperlai/Develop/web/mlshb/accident-chart/node_modules/laravel-elixir-webpack/node_modules/gulp-webpack/node_modules/through/index.js:36:16)
    at Stream.stream.queue.stream.push (/Users/casperlai/Develop/web/mlshb/accident-chart/node_modules/laravel-elixir-webpack/node_modules/gulp-webpack/node_modules/through/index.js:45:5)
    at /Users/casperlai/Develop/web/mlshb/accident-chart/node_modules/laravel-elixir-webpack/node_modules/gulp-webpack/index.js:137:16
    at Array.forEach (native)
    at Tapable.<anonymous> (/Users/casperlai/Develop/web/mlshb/accident-chart/node_modules/laravel-elixir-webpack/node_modules/gulp-webpack/index.js:130:39)
    at Tapable.applyPluginsAsync (/Users/casperlai/Develop/web/mlshb/accident-chart/node_modules/laravel-elixir-webpack/node_modules/gulp-webpack/node_modules/webpack/node_modules/tapable/lib/Tapable.js:71:13)

```
