### PR TITLE
Fix outputDir configuration option

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,8 +16,6 @@ Elixir.extend('webpack', function (src, options) {
 
     var paths = prepGulpPaths(src, options.srcDir, options.outputDir);
 
-    // this.log(paths.src, paths.output);
-
     new Elixir.Task('webpack', function () {
         return (
             gulp.src(src)

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ Elixir.extend('webpack', function (src, options) {
         outputDir: config.get('public.js.outputFolder'),
     }, options);
 
-    var paths = prepGulpPaths(src, options.srcDir, outputDir);
+    var paths = prepGulpPaths(src, options.srcDir, options.outputDir);
 
     this.log(paths.src, paths.output);
 

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ Elixir.extend('webpack', function (src, options) {
 
     var paths = prepGulpPaths(src, options.srcDir, options.outputDir);
 
-    this.log(paths.src, paths.output);
+    // this.log(paths.src, paths.output);
 
     new Elixir.Task('webpack', function () {
         return (


### PR DESCRIPTION
this fixes an error at startup

var paths = prepGulpPaths(src, options.srcDir, outputDir);

ReferenceError: outputDir is not defined
