### PR TITLE
make output use default source name

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,9 @@ Elixir.extend('webpack', function (src, options) {
         debug:     ! config.production,
         srcDir:    config.get('assets.js.folder'),
         outputDir: config.get('public.js.outputFolder'),
+        output: {
+          filename: src
+        }
     }, options);
 
     new Elixir.Task('webpack', function () {


### PR DESCRIPTION
not sure if this will be helpful, but it save a few keystroke to name the output file when the output filename is actually the same as input filename.
